### PR TITLE
Use `arbitrarySizedNatural` to generate natural numbers in test suite.

### DIFF
--- a/components/monoidmap-test/Test/Common.hs
+++ b/components/monoidmap-test/Test/Common.hs
@@ -71,7 +71,7 @@ import Test.QuickCheck
     , Function (..)
     , Property
     , Testable
-    , arbitrarySizedIntegral
+    , arbitrarySizedNatural
     , checkCoverage
     , coarbitraryIntegral
     , coarbitraryShow
@@ -112,7 +112,7 @@ instance (Function k, Function v, Ord k, MonoidNull v) =>
     function = functionMap MonoidMap.toMap MonoidMap.fromMap
 
 instance Arbitrary Natural where
-    arbitrary = arbitrarySizedIntegral
+    arbitrary = arbitrarySizedNatural
     shrink = shrinkIntegral
 
 instance CoArbitrary Natural where


### PR DESCRIPTION
This PR adjusts the test suite to use `arbitrarySizedNatural` instead of `arbitrarySizedIntegral` when generating natural numbers.

This should prevent the following class of error, observed with QuickCheck `2.14.3`:

```hs
  components/monoidmap-test/Data/MonoidMap/Internal/ValiditySpec.hs:327:5:
  1) Data.MonoidMap.Internal.Validity, MonoidMap (Key 4) (MonoidMap (Key 2) (Sum Natural)), propValid_monus
       *** Failed! Exception while generating shrink-list: 'arithmetic underflow' (after 3 tests):
       Exception thrown while showing test case: 'arithmetic underflow'
       fromList []
```